### PR TITLE
Add types export + Troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ const config = {
 const myChart = new Chart(document.querySelector('#myChart'), config);
 ```
 
+## Troubleshooting
+
+If you're seeing this error:
+
+```text
+Error: This method is not implemented: Check that a complete date adapter is provided.
+```
+
+This means the library didn't actually initialize.
+This could happen because the side-effect import is being tree-shaken during the build.
+
+Use an explicit run-time import instead:
+
+```javascript
+await import("chartjs-adapter-intl")
+```
+
 ## Development
 
 To build the project, run:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "types": "dist/chartjs-adapter-intl.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/chartjs-adapter-intl.d.ts",
       "import": "./dist/chartjs-adapter-intl.mjs",
       "require": "./dist/chartjs-adapter-intl.cjs"
     }


### PR DESCRIPTION
`chartjs-adapter-intl` doesn't work in Nuxt production build when simply imported. It's being excluded by the tree shaking.

It works when explicitly imported with `await import("chartjs-adapter-intl")` but then the typings break because `package.json` doesn't refer to them (even though `unbuild` creates them).

The PR adds the troubleshooting section and adds the missing export.